### PR TITLE
Adding exception KeyError and changing currency_choices

### DIFF
--- a/control/views.py
+++ b/control/views.py
@@ -144,12 +144,15 @@ def currency_converter(request):
             unit_to = form.cleaned_data['unit_to'].upper()
             unit_value = form.cleaned_data['unit_value']
 
-            url = 'https://api.exchangeratesapi.io/latest?base='+unit
-            currency_values = requests.get(url).json()
-            currency_value = currency_values['rates'][unit_to]
+            try:
+                url = 'https://api.exchangeratesapi.io/latest?base='+unit
+                currency_values = requests.get(url).json()
+                currency_value = currency_values['rates'][unit_to]
+                calculations = unit_value * currency_value
+                result = '{} {}'.format(calculations, unit_to)
 
-            calculations = unit_value * currency_value
-            result = '{} {}'.format(calculations, unit_to)
+            except KeyError:
+                result = '{} {}'.format(unit_value, unit_to)
     else:
         form = CurrencyConverter()
 

--- a/control/views.py
+++ b/control/views.py
@@ -153,8 +153,9 @@ def currency_converter(request):
             except KeyError:
                 currency_value = 1
 
-            calculations = unit_value * currency_value
-            result = '{} {}'.format(calculations, unit_to)
+            finally:
+                calculations = unit_value * currency_value
+                result = '{} {}'.format(calculations, unit_to)
     else:
         form = CurrencyConverter()
 

--- a/control/views.py
+++ b/control/views.py
@@ -144,15 +144,17 @@ def currency_converter(request):
             unit_to = form.cleaned_data['unit_to'].upper()
             unit_value = form.cleaned_data['unit_value']
 
+            url = 'https://api.exchangeratesapi.io/latest?base=' + unit
+            currency_values = requests.get(url).json()
+
             try:
-                url = 'https://api.exchangeratesapi.io/latest?base='+unit
-                currency_values = requests.get(url).json()
                 currency_value = currency_values['rates'][unit_to]
-                calculations = unit_value * currency_value
-                result = '{} {}'.format(calculations, unit_to)
 
             except KeyError:
-                result = '{} {}'.format(unit_value, unit_to)
+                currency_value = 1
+
+            calculations = unit_value * currency_value
+            result = '{} {}'.format(calculations, unit_to)
     else:
         form = CurrencyConverter()
 


### PR DESCRIPTION
-Adding exception KeyError. In one case particularly when unit and unit_to equals 'EUR' these can't be found in the API which ends in a KeyError.

-Changing currency_choices for better readability in front end.